### PR TITLE
Eliminate warnings in lexer

### DIFF
--- a/p4_hlir/frontend/tokenizer.py
+++ b/p4_hlir/frontend/tokenizer.py
@@ -134,12 +134,7 @@ class P4Lexer:
         'SEMI', 'COLON', # ; :
         'APOSTROPHE', # '
 
-        # pre-processor
-        'PPHASH', # '#'
-
         'PRAGMA', 'STR',
-
-        # 'PPHASH',
     ) + keywords
     
     # Regular expression rules for simple tokens
@@ -239,6 +234,8 @@ class P4Lexer:
         r'.+'
         return t
         
+    def t_pragma_error(self, t):
+        self._error('invalid pragma', t)
 
     ##
     ## Rules for the ppline state


### PR DESCRIPTION
The p4-hlir lexer currently prints several warnings every time it is invoked.

> WARNING: No error rule is defined for exclusive state 'pragma'
> WARNING: Token 'PPHASH' defined, but not used
> WARNING: There is 1 unused token

This commit surpresses those warnings by:

* Eliminating the `PPHASH` token, while retaining the `t_PPHASH` rule so that location information encoded in `#line` directives is correctly tracked.

* Adding a `t_pragma_error` rule.