### PR TITLE
add support for "modify_field_rng_uniform"

### DIFF
--- a/p4_hlir/frontend/primitives.json
+++ b/p4_hlir/frontend/primitives.json
@@ -471,5 +471,26 @@
                     "data_width" : "field"
                 }
             }
+    },
+    "modify_field_rng_uniform" :
+    {
+        "num_args" : 3,
+        "args" : ["field", "value1", "value2"],
+        "properties" : {
+                "field" : {
+                    "type" : ["field"],
+                    "access" : "write"
+                },
+                "value1" : {
+                    "type" : ["field", "int", "table_entry_data"],
+                    "access" : "read",
+                    "data_width" : "field"
+                },
+                "value2" : {
+                    "type" : ["field", "int", "table_entry_data"],
+                    "access" : "read",
+                    "data_width" : "field"
+                }
+            }
     }
 }


### PR DESCRIPTION
"modify_field_rng_uniform" is a standard primitive action defined in P4 Language Specification(Version 1.0.4). However, current "p4-hlir" repository does not have support for it, which leads to a failure when running "p4-graph switch.p4" within the "p4lang/switch“ repository. Therefore, I added support for this action.  