### PR TITLE
cpp: do not use system-specific defines or headers

### DIFF
--- a/p4_hlir/frontend/preprocessor.py
+++ b/p4_hlir/frontend/preprocessor.py
@@ -24,7 +24,7 @@ class PreprocessorException(Exception):
 class Preprocessor(object):
     def __init__(self):
         self.executable_path = "gcc"
-        self.args = ["-E", "-x", "c", "-w"]
+        self.args = ["-E", "-x", "c", "-w", "-undef", "-nostdinc"]
 
     def preprocess_file(self, filename, dest=None):
         return self._preprocess(filename, "", dest)


### PR DESCRIPTION
This prevents inadvertent rewrites of tokens such as "linux" due to the
system having an implicit `#define linux 1`.