### PR TITLE
Add support for modify_field_rng_uniform

### DIFF
--- a/p4_hlir/frontend/primitives.json
+++ b/p4_hlir/frontend/primitives.json
@@ -471,5 +471,26 @@
                     "data_width" : "field"
                 }
             }
+    },
+    "modify_field_rng_uniform" :
+    {
+        "num_args" : 3,
+        "args" : ["field", "value1", "value2"],
+        "properties" : {
+                "field" : {
+                    "type" : ["field"],
+                    "access" : "write"
+                },
+                "value1" : {
+                    "type" : ["field", "int", "table_entry_data"],
+                    "access" : "read",
+                    "data_width" : "field"
+                },
+                "value2" : {
+                    "type" : ["field", "int", "table_entry_data"],
+                    "access" : "read",
+                    "data_width" : "field"
+                }
+            }
     }
 }


### PR DESCRIPTION
Hi, modify_field_rng_uniform is a primitive action defined in the P4 specification. Unfortunately, this action is not supported at this moment. This commit should fix it.

Juraj Kubiš, Netcope Technologies (p4.org member)